### PR TITLE
Pass transparent arg to render method

### DIFF
--- a/nucanvas/nucanvas.py
+++ b/nucanvas/nucanvas.py
@@ -30,8 +30,8 @@ class NuCanvas(GroupShape):
     return shapes
 
 
-  def render(self):
-    self.surf.render(self)
+  def render(self, transparent):
+    self.surf.render(self, transparent)
     
   def add_marker(self, name, shape, ref=(0,0), orient='auto', units='stroke'):
     self.markers[name] = (shape, ref, orient, units)

--- a/symbolator.py
+++ b/symbolator.py
@@ -565,7 +565,7 @@ def main():
       sym = make_symbol(comp, extractor, args.title, args.no_type)
       sym.draw(0,0, nc)
 
-      nc.render()
+      nc.render(args.transparent)
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
Currently the `--transparent/-t` command line argument does not do anything because it is not passed to the renderer.