### PR TITLE
Add nix flake

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,12 @@ passes it through 2to3.
 
 The Pango library is used compute the dimensions of a text layout. There is no standard package to get the Pango Python bindings installed. It is a part of the Gtk+ library which is accessed either through the PyGtk or PyGObject APIs, both of which are supported by Symbolator. You should make sure that one of these libraries is available before installing Symbolator. A `Windows installer <http://www.pygtk.org/downloads.html>`_ is available. For Linux distributions you should install the relevant libraries with your package manager.
 
+If you are running linux you can use the nix package manager to build and run symbolator without installing it:
+
+```
+nix run github:kevinpt/symbolator
+```
+
 Licensing
 ---------
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,39 @@
+{ pkgs ? import <nixpkgs> { } }:
+let
+  hdlparse = pkgs.python2Packages.buildPythonPackage rec {
+    pname = "hdlparse";
+    version = "1.0.4";
+    src = pkgs.fetchFromGitHub {
+      owner = "kevinpt";
+      repo = "hdlparse";
+      rev = "be7cdab08a8c18815cc4504003ce9ca7fff41022";
+      sha256 = "sha256-KJXl9lQY6xYJkaS41F8V1jGz5jhu0oPhb/lQVj/gj18="; # TODO
+    };
+  };
+in
+with pkgs;
+python2Packages.buildPythonPackage rec {
+  name = "symbolator";
+  version = "1.0.2";
+  src = ./.;
+  nativeBuildInputs = [ wrapGAppsHook gobject-introspection ];
+
+  propagatedBuildInputs = [
+    pango
+    hdlparse
+    python2Packages.pygobject3
+    python2Packages.pycairo
+    python2Packages.setuptools
+  ];
+
+  meta = with lib; {
+    description = "A component diagramming tool for VHDL and Verilog";
+    longDescription = ''
+      Symbolator is a component diagramming tool for VHDL and Verilog. It will parse HDL source files, extract components or modules and render them as an image.
+    '';
+    homepage = "http://kevinpt.github.io/symbolator";
+    license = licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "symbolator";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Symbolator is a component diagramming tool for VHDL and Verilog.";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      rec {
+        name = "Symbolator";
+        packages.symbolator = import ./default.nix { pkgs = nixpkgs.legacyPackages.${system}; };
+        packages.default = packages.symbolator;
+      }
+    );
+}

--- a/nucanvas/cairo_backend.py
+++ b/nucanvas/cairo_backend.py
@@ -14,6 +14,9 @@ try:
   import pangocairo
   use_pygobject = False
 except ImportError:
+  import gi
+  gi.require_version('Pango', '1.0')
+  gi.require_version('PangoCairo', '1.0')
   from gi.repository import Pango as pango
   from gi.repository import PangoCairo as pangocairo
   use_pygobject = True


### PR DESCRIPTION
This pull request will add support for reproducibly building and running symbolator using the nix package manger. This way you can run symbolator without the need to install any dependencies like PyGObject.

```
nix run github:zebreus/symbolator
```